### PR TITLE
Md5 openssl3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(fastafs)
 # Do this once in a while - find different compiler warnings
 #set(CMAKE_CXX_COMPILER             "clang++")
 
-set(PROJECT_VERSION "1.10.0")
+set(PROJECT_VERSION "1.11.0")
 set(PACKAGE_URL "https://github.com/yhoogstrate/fastafs")
 set(PACKAGE_BUGREPORT "${PACKAGE_URL}/issues")
 

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,11 @@
+2024-04-30
+   * v1.10.0
+   * Implements SHA1 and MD5 through OpenSSL's EVP interface as
+     old interface is deprecated as of OpenSSL 3.0
+
 2023-01-22
-   * v.10.0
+
+   * v1.10.0
    * Better ninja/meson support
    * Code clean-ups
    * Restructured the chunked_reader class and subclasses according to

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 2024-04-30
-   * v1.10.0
+
+   * v1.11.0
    * Implements SHA1 and MD5 through OpenSSL's EVP interface as
      old interface is deprecated as of OpenSSL 3.0
 

--- a/include/chunked_reader.hpp
+++ b/include/chunked_reader.hpp
@@ -87,8 +87,8 @@ public:
 /**
  * Reads a flat or compressed file per chunk, with random access. Current
  * implemented formats are flat files and zstd-seekable compressed files.
- * 
- * @param 
+ *
+ * @param
  */
 class chunked_reader // master chunked_reader
 {

--- a/include/fasta_to_fastafs.hpp
+++ b/include/fasta_to_fastafs.hpp
@@ -1,7 +1,7 @@
 
 #include <vector>
 
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 
 #include "config.hpp"
 #include "utils.hpp"
@@ -50,7 +50,7 @@ public:
     uint32_t padding;
 
     // the followin should be member of a conversion struct, because they're not related to the original 2bit format:
-    MD5_CTX ctx;
+    EVP_MD_CTX *mdctx;
     unsigned char md5_digest[MD5_DIGEST_LENGTH];
 
     std::vector<uint32_t> n_block_starts;
@@ -89,7 +89,9 @@ public:
             fprintf(stderr, "[fasta_to_fastafs::init] sequence name truncated to 255 charaters: %s\n", name.c_str());
             this->name = this->name.substr(0, 255);
         }
-        MD5_Init(&this->ctx);
+        
+        this->mdctx = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(this->mdctx, EVP_md5(), NULL);
     }
 
     void flush();

--- a/include/fasta_to_fastafs.hpp
+++ b/include/fasta_to_fastafs.hpp
@@ -89,7 +89,7 @@ public:
             fprintf(stderr, "[fasta_to_fastafs::init] sequence name truncated to 255 charaters: %s\n", name.c_str());
             this->name = this->name.substr(0, 255);
         }
-        
+
         this->mdctx = EVP_MD_CTX_new();
         EVP_DigestInit_ex(this->mdctx, EVP_md5(), NULL);
     }

--- a/include/ucsc2bit_to_fastafs.hpp
+++ b/include/ucsc2bit_to_fastafs.hpp
@@ -35,7 +35,6 @@ struct ucsc2bit_seq_header {
 struct ucsc2bit_seq_header_conversion_data {
     // the followin should be member of a conversion struct, because they're not related to the original 2bit format:
     EVP_MD_CTX *mdctx;
-    //MD5_CTX ctx; // needs to be initialized in a constructor, if possible
     unsigned char md5_digest[MD5_DIGEST_LENGTH];
 
     uint32_t N;// number of N (unknown) nucleotides (n - N = total 2bit compressed nucleotides)
@@ -46,7 +45,7 @@ struct ucsc2bit_seq_header_conversion_data {
     {
         this->mdctx = EVP_MD_CTX_new();
         EVP_DigestInit_ex(this->mdctx, EVP_md5(), NULL);
-        
+
         //MD5_Init(&this->ctx);
     }
 };

--- a/include/ucsc2bit_to_fastafs.hpp
+++ b/include/ucsc2bit_to_fastafs.hpp
@@ -3,7 +3,8 @@
 #include <string.h>
 
 #include <vector>
-#include <openssl/md5.h>
+#include <openssl/md5.h> // old
+#include <openssl/evp.h> // new
 
 #include "config.hpp"
 #include "utils.hpp"
@@ -34,6 +35,7 @@ struct ucsc2bit_seq_header {
 
 struct ucsc2bit_seq_header_conversion_data {
     // the followin should be member of a conversion struct, because they're not related to the original 2bit format:
+    EVP_MD_CTX *mdctx;
     MD5_CTX ctx; // needs to be initialized in a constructor, if possible
     unsigned char md5_digest[MD5_DIGEST_LENGTH];
 
@@ -43,7 +45,10 @@ struct ucsc2bit_seq_header_conversion_data {
 
     ucsc2bit_seq_header_conversion_data(): N(0)
     {
-        MD5_Init(&this->ctx);
+        this->mdctx = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(this->mdctx, EVP_md5(), NULL);
+        
+        //MD5_Init(&this->ctx);
     }
 };
 

--- a/include/ucsc2bit_to_fastafs.hpp
+++ b/include/ucsc2bit_to_fastafs.hpp
@@ -3,8 +3,7 @@
 #include <string.h>
 
 #include <vector>
-#include <openssl/md5.h> // old
-#include <openssl/evp.h> // new
+#include <openssl/evp.h>
 
 #include "config.hpp"
 #include "utils.hpp"
@@ -36,7 +35,7 @@ struct ucsc2bit_seq_header {
 struct ucsc2bit_seq_header_conversion_data {
     // the followin should be member of a conversion struct, because they're not related to the original 2bit format:
     EVP_MD_CTX *mdctx;
-    MD5_CTX ctx; // needs to be initialized in a constructor, if possible
+    //MD5_CTX ctx; // needs to be initialized in a constructor, if possible
     unsigned char md5_digest[MD5_DIGEST_LENGTH];
 
     uint32_t N;// number of N (unknown) nucleotides (n - N = total 2bit compressed nucleotides)

--- a/src/chunked_reader.cpp
+++ b/src/chunked_reader.cpp
@@ -338,27 +338,27 @@ void ContextZstdSeekable::seek(off_t arg_offset)
 ContextZstdSeekable::~ContextZstdSeekable()
 {
     if(this->fh != nullptr) {
-        
+
         //ZSTD_seekable_free(this->fh_zstd->seekable);
         //delete this->fh_zstd->seekable;
         //delete this->fh_zstd->fin;
 
         fclose_orDie(this->fh->fin);
         delete this->fh;
-        
+
     }
-    
-    
+
+
     if(this->seekable != nullptr) {
         ZSTD_seekable_free(this->seekable);
         //delete this->ZSTD_seekable;
     }
-    
-    
+
+
     //char* const buffOut = (char*) malloc_orDie(buffOutSize);
     //ZSTD_seekable* const seekable = ZSTD_seekable_create(); //@todo -> in constructor, check if not NULL
 
-    
+
 
     //throw std::runtime_error("[ContextUncompressed::~ContextUncompressed] not implemented.\n");
 }

--- a/src/chunked_reader.cpp
+++ b/src/chunked_reader.cpp
@@ -344,6 +344,10 @@ ContextZstdSeekable::~ContextZstdSeekable()
         //delete this->fh_zstd->fin;
 
         fclose_orDie(this->fh->fin);
+        if(this->buffOut != nullptr)
+        {
+            free(this->buffOut);
+        }
         delete this->fh;
 
     }

--- a/src/fasta_to_fastafs.cpp
+++ b/src/fasta_to_fastafs.cpp
@@ -136,8 +136,13 @@ void fasta_to_fastafs_seq::finish_sequence(std::ofstream &fh_fastafs)
     // write checksum
     unsigned int md5_digest_len = EVP_MD_size(EVP_md5());
     EVP_DigestFinal_ex(this->mdctx, this->md5_digest, &md5_digest_len);
+    EVP_MD_CTX_free(mdctx);
+    
 
     fh_fastafs.write(reinterpret_cast<char *>(&this->md5_digest), (size_t) 16);
+    
+    //OPENSSL_free(md5_digest);
+
 
     // M blocks
     uint_to_fourbytes(buffer, (uint32_t) this->m_block_starts.size());

--- a/src/fasta_to_fastafs.cpp
+++ b/src/fasta_to_fastafs.cpp
@@ -136,8 +136,7 @@ void fasta_to_fastafs_seq::finish_sequence(std::ofstream &fh_fastafs)
     // write checksum
     unsigned int md5_digest_len = EVP_MD_size(EVP_md5());
     EVP_DigestFinal_ex(this->mdctx, this->md5_digest, &md5_digest_len);
-    //MD5_Final(this->md5_digest, &this->ctx);
-    
+
     fh_fastafs.write(reinterpret_cast<char *>(&this->md5_digest), (size_t) 16);
 
     // M blocks
@@ -279,15 +278,12 @@ size_t fasta_to_fastafs(const std::string &fasta_file, const std::string &fastaf
     std::string line;
     std::ifstream fh_fasta(fasta_file.c_str(), std::ios :: in | std::ios :: binary);
     std::ofstream fh_fastafs(fastafs_file.c_str(), std::ios :: out | std::ios :: binary);
-    
+
     s = nullptr;
-    
-    if(!fh_fasta.is_open() or !fh_fastafs.is_open())
-    {
+
+    if(!fh_fasta.is_open() or !fh_fastafs.is_open()) {
         throw std::invalid_argument("[fasta_to_fastafs:1] Could not open one of file: " + fasta_file + " | " + fastafs_file);
-    }
-    else
-    {
+    } else {
         fh_fastafs << FASTAFS_MAGIC;
         fh_fastafs << FASTAFS_VERSION;
 
@@ -312,8 +308,7 @@ size_t fasta_to_fastafs(const std::string &fasta_file, const std::string &fastaf
         if(s != nullptr) {
             bool running = getline(fh_fasta, line).good();
             while(running) {
-                if(line[0] == '>')
-                {
+                if(line[0] == '>') {
                     // more N-bytes than 2-bit bytes - 4bit is more efficient
                     if(auto_recompress_to_fourbit && s->current_dict == DICT_TWOBIT && s->N_bytes_used() > s->twobit_bytes_used()) {
                         fh_fasta.seekg(s->file_offset_in_fasta, std::ios::beg);

--- a/src/fastafs.cpp
+++ b/src/fastafs.cpp
@@ -575,6 +575,8 @@ std::string fastafs_seq::md5(ffs2f_init_seq* cache, chunked_reader &fh)
 
     char md5_hash[32 + 1];
     md5_digest_to_hash(md5_digest, md5_hash);
+    
+    OPENSSL_free(md5_digest);
 
     return std::string(md5_hash);
 }
@@ -740,6 +742,7 @@ void fastafs::load(std::string afilename)
                 fh_in.read(name, namesize);
                 name[(unsigned char) memblock[0]] = '\0';
                 s->name = std::string(reinterpret_cast<char*>(name));
+                delete[] name;
 
                 // set cursor and save sequence data position
                 fh_in.read(memblock, 4);

--- a/src/fastafs.cpp
+++ b/src/fastafs.cpp
@@ -698,7 +698,6 @@ void fastafs::load(std::string afilename)
             fh_in.read(memblock, 14);
             memblock[16] = '\0';
 
-
             // check magic
             for(i = 0 ; i < 4;  i++) {
                 if(memblock[i] != FASTAFS_MAGIC[i]) {

--- a/src/fastafs.cpp
+++ b/src/fastafs.cpp
@@ -7,9 +7,6 @@
 #include <string.h>
 //#include <filesystem>
 
-#include <openssl/sha.h>
-#include <openssl/md5.h> // old
-#include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
@@ -206,8 +203,8 @@ template <class T> inline uint32_t fastafs_seq::view_fasta_chunk_generalized(
     uint32_t written = 0;
 
 
-    if(written >= buffer_size)
-    { // requesting a buffer of size=0, should throw an exception?
+    if(written >= buffer_size) {
+        // requesting a buffer of size=0, should throw an exception?
         return written;
     }
 
@@ -215,8 +212,7 @@ template <class T> inline uint32_t fastafs_seq::view_fasta_chunk_generalized(
 
 
     size_t pos_limit = this->name.size() + 2;
-    if(pos < pos_limit)
-    {
+    if(pos < pos_limit) {
         const std::string header = ">" + this->name + "\n";
 
         const uint32_t tocopy = (uint32_t) std::min(pos_limit - pos, buffer_size); // size to be copied
@@ -224,8 +220,7 @@ template <class T> inline uint32_t fastafs_seq::view_fasta_chunk_generalized(
 
         written += (uint32_t) copied;
 
-        if(written >= buffer_size)
-        {
+        if(written >= buffer_size) {
             return written;
         }
 
@@ -461,7 +456,7 @@ std::string fastafs_seq::sha1(ffs2f_init_seq* cache, chunked_reader &fh)
     EVP_MD_CTX *mdctx;
     mdctx = EVP_MD_CTX_new();
     EVP_DigestInit_ex(mdctx, EVP_sha1(), NULL);
-    
+
 
     //SHA_CTX ctx;
     //SHA1_Init(&ctx);
@@ -479,31 +474,27 @@ std::string fastafs_seq::sha1(ffs2f_init_seq* cache, chunked_reader &fh)
                                chunksize,
                                header_offset + (i * chunksize),
                                fh);
-        
+
         //SHA1_Update(&ctx, chunk, chunksize);
         EVP_DigestUpdate(mdctx, chunk, chunksize); // new
 
     }
 
-    if(remaining_bytes > 0)
-    {
+    if(remaining_bytes > 0) {
         this->view_fasta_chunk(cache, chunk, remaining_bytes, header_offset + (n_iterations * chunksize), fh);
-    
+
         //SHA1_Update(&ctx, chunk, remaining_bytes);
         EVP_DigestUpdate(mdctx, chunk, remaining_bytes); // new
-        
+
         //chunk[remaining_bytes] = '\0';
     }
 
-    unsigned char cur_sha1_digest[SHA_DIGEST_LENGTH];
-    
 
-    unsigned char *md5_digest;
-    unsigned int md5_digest_len = EVP_MD_size(EVP_md5());
-    md5_digest = (unsigned char *)OPENSSL_malloc(md5_digest_len);
-    EVP_DigestFinal_ex(mdctx, cur_sha1_digest, &md5_digest_len);
+    unsigned int sha1_digest_len = EVP_MD_size(EVP_md5());
+    unsigned char cur_sha1_digest[sha1_digest_len];
+    EVP_DigestFinal_ex(mdctx, cur_sha1_digest, &sha1_digest_len);
     EVP_MD_CTX_free(mdctx);
-        
+
     //SHA1_Final(cur_sha1_digest, &ctx);
     //fh->clear(); // because gseek was done before
 
@@ -556,7 +547,6 @@ std::string fastafs_seq::md5(ffs2f_init_seq* cache, chunked_reader &fh)
         }
 
         EVP_DigestUpdate(mdctx, chunk, written); // new
-        //MD5_Update(&ctx, chunk, written); // old
     }
 
     if(remaining_bytes > 0) {
@@ -567,26 +557,23 @@ std::string fastafs_seq::md5(ffs2f_init_seq* cache, chunked_reader &fh)
         }
 
         EVP_DigestUpdate(mdctx, chunk, written); // new
-        //MD5_Update(&ctx, chunk, written); // old
+
         chunk[remaining_bytes] = '\0';
     }
 
     //printf(" (%i * %i) + %i =  %i  = %i\n", n_iterations , chunksize, remaining_bytes , (n_iterations * chunksize) + remaining_bytes , this->n);
-    
-    
-    //unsigned char cur_md5_digest[MD5_DIGEST_LENGTH];
-    //MD5_Final(cur_md5_digest, &ctx);
-    
+
+
     //fh->clear(); // because gseek was done before
 
-    
+
     unsigned char *md5_digest;
     unsigned int md5_digest_len = EVP_MD_size(EVP_md5());
     md5_digest = (unsigned char *)OPENSSL_malloc(md5_digest_len);
     EVP_DigestFinal_ex(mdctx, md5_digest, &md5_digest_len);
     EVP_MD_CTX_free(mdctx);
-    
-    char md5_hash[32 + 1]; 
+
+    char md5_hash[32 + 1];
     md5_digest_to_hash(md5_digest, md5_hash);
 
     return std::string(md5_hash);

--- a/src/ucsc2bit.cpp
+++ b/src/ucsc2bit.cpp
@@ -308,6 +308,7 @@ void ucsc2bit::load(std::string afilename)
 
                 name[(unsigned char) memblock[0]] = '\0';
                 s->name = std::string(name);
+                delete[] name;
 
                 // file offset for seq-block
                 if(!file.read((char *) &memblock[0], 4)) {

--- a/src/ucsc2bit_to_fastafs.cpp
+++ b/src/ucsc2bit_to_fastafs.cpp
@@ -143,7 +143,8 @@ size_t ucsc2bit_to_fastafs(std::string ucsc2bit_file, std::string fastafs_file)
                     n_ahead = s->n_block_sizes[n_n];
                 }
                 if(n_ahead > 0) {// we are in an N block on an N base
-                    MD5_Update(&t->ctx, nn, 1);
+                    EVP_DigestUpdate(t->mdctx, nn, 1); // new
+                    //MD5_Update(&t->ctx, nn, 1);
                     n_ahead -= 1;
                     if(n_ahead == 0) {
                         n_n++;
@@ -159,22 +160,26 @@ size_t ucsc2bit_to_fastafs(std::string ucsc2bit_file, std::string fastafs_file)
                     case 'u':
                     case 'U':
                         t_out.set(twobit_byte::iterator_to_offset(k), 0);
-                        MD5_Update(&t->ctx, nt, 1);
+                        EVP_DigestUpdate(t->mdctx, nt, 1); // new
+                        //MD5_Update(&t->ctx, nt, 1);
                         break;
                     case 'c':
                     case 'C':
                         t_out.set(twobit_byte::iterator_to_offset(k), 1);
-                        MD5_Update(&t->ctx, nc, 1);
+                        EVP_DigestUpdate(t->mdctx, nc, 1); // new
+                        //MD5_Update(&t->ctx, nc, 1);
                         break;
                     case 'a':
                     case 'A':
                         t_out.set(twobit_byte::iterator_to_offset(k), 2);
-                        MD5_Update(&t->ctx, na, 1);
+                        EVP_DigestUpdate(t->mdctx, na, 1); // new
+                        //MD5_Update(&t->ctx, na, 1);
                         break;
                     case 'g':
                     case 'G':
                         t_out.set(twobit_byte::iterator_to_offset(k), 3);
-                        MD5_Update(&t->ctx, ng, 1);
+                        EVP_DigestUpdate(t->mdctx, ng, 1); // new
+                        //MD5_Update(&t->ctx, ng, 1);
                         break;
                     }
                     if(k % 4 == 3) {
@@ -190,7 +195,10 @@ size_t ucsc2bit_to_fastafs(std::string ucsc2bit_file, std::string fastafs_file)
                 // @todo hf_fastsfs << t_out.data
                 fh_fastafs.write((char *) & (t_out.data), (size_t) 1); // name size
             }
-            MD5_Final(t->md5_digest, &t->ctx);
+
+            unsigned int md5_digest_len = EVP_MD_size(EVP_md5());
+            EVP_DigestFinal_ex(t->mdctx, t->md5_digest, &md5_digest_len);
+            //MD5_Final(t->md5_digest, &t->ctx);
 
             // write N blocks
             uint_to_fourbytes(buffer, s->n_blocks);

--- a/src/ucsc2bit_to_fastafs.cpp
+++ b/src/ucsc2bit_to_fastafs.cpp
@@ -139,27 +139,26 @@ size_t ucsc2bit_to_fastafs(std::string ucsc2bit_file, std::string fastafs_file)
                 }
 
                 // check if N
-                if(j == next_n)
-                { // new next block has opened
+                if(j == next_n) {
+                    // new next block has opened
                     n_ahead = s->n_block_sizes[n_n];
                 }
-                
-                if(n_ahead > 0)
-                {// we are in an N block on an N base
+
+                if(n_ahead > 0) {
+                    // we are in an N block on an N base
                     EVP_DigestUpdate(t->mdctx, nn, 1); // new
                     //MD5_Update(&t->ctx, nn, 1);
                     n_ahead -= 1;
                     if(n_ahead == 0) {
                         n_n++;
-                        
+
                         if(s->n_blocks > n_n) {
                             next_n = s->n_block_starts[n_n];
                             n_ahead = 0;
                         }
                     }
-                }
-                else
-                { // non-N char
+                } else {
+                    // non-N char
                     switch(decoded_in[j % 4]) {
                     case 't':
                     case 'T':

--- a/src/ucsc2bit_to_fastafs.cpp
+++ b/src/ucsc2bit_to_fastafs.cpp
@@ -203,7 +203,10 @@ size_t ucsc2bit_to_fastafs(std::string ucsc2bit_file, std::string fastafs_file)
 
             unsigned int md5_digest_len = EVP_MD_size(EVP_md5());
             EVP_DigestFinal_ex(t->mdctx, t->md5_digest, &md5_digest_len);
-            //MD5_Final(t->md5_digest, &t->ctx);
+            
+            EVP_MD_CTX_free(t->mdctx);
+
+            
 
             // write N blocks
             uint_to_fourbytes(buffer, s->n_blocks);

--- a/src/ucsc2bit_to_fastafs.cpp
+++ b/src/ucsc2bit_to_fastafs.cpp
@@ -139,21 +139,27 @@ size_t ucsc2bit_to_fastafs(std::string ucsc2bit_file, std::string fastafs_file)
                 }
 
                 // check if N
-                if(j == next_n) { // new next block has opened
+                if(j == next_n)
+                { // new next block has opened
                     n_ahead = s->n_block_sizes[n_n];
                 }
-                if(n_ahead > 0) {// we are in an N block on an N base
+                
+                if(n_ahead > 0)
+                {// we are in an N block on an N base
                     EVP_DigestUpdate(t->mdctx, nn, 1); // new
                     //MD5_Update(&t->ctx, nn, 1);
                     n_ahead -= 1;
                     if(n_ahead == 0) {
                         n_n++;
+                        
                         if(s->n_blocks > n_n) {
                             next_n = s->n_block_starts[n_n];
                             n_ahead = 0;
                         }
                     }
-                } else { // non-N char
+                }
+                else
+                { // non-N char
                     switch(decoded_in[j % 4]) {
                     case 't':
                     case 'T':

--- a/test/cache/test_cache.cpp
+++ b/test/cache/test_cache.cpp
@@ -632,6 +632,8 @@ BOOST_AUTO_TEST_CASE(test_cache_hybrid)
         //std::string uppercase = ">seq.1[ACTG]\nACTAGCTACG\nATCGAGTCAG\nACATGCTN\n>seq.2[ACUG]\nACTAGCTACG\nATCGAGTCAG\nACATGCTN\n>seq.3[IUPEC]\nNNDV\n>seq.4[ACTG]\nACTAGCTACG\nATCGAGTCAG\nACATGCTN\n>seq.5[ACUG]\nACTAGCTACG\nATCGAGTCAG\nACATGCTN\n>seq.6[IUPEC]\nYHVA----BH\nUYVK\n";
         BOOST_CHECK(output.compare(uppercase) == 0);
     }
+    
+    delete cache_p10;
 }
 
 

--- a/test/fastafs/test_fastafs.cpp
+++ b/test/fastafs/test_fastafs.cpp
@@ -403,6 +403,9 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         written = fs.view_sequence_region(cache_p0, (strchr(arg, '/') + 5), buffer, READ_BUFFER_SIZE, 0);
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 't');
+        
+        delete cache_p0;
+        delete[] buffer;
     }
     {
         ffs2f_init* cache_p0 = fs.init_ffs2f(0, true); // @ padding 0 as it reflects actual plain sequence
@@ -421,6 +424,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 't');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -440,6 +444,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'c');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -459,6 +464,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'g');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -478,6 +484,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 0);
         //BOOST_CHECK_EQUAL(buffer[0], '\n');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -499,6 +506,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'A');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -519,6 +527,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'C');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -538,6 +547,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -558,6 +568,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'n');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -577,6 +588,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'n');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -596,6 +608,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'n');
 
+        delete cache_p0;
         delete[] buffer;
     }
     {
@@ -615,6 +628,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'n');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -636,6 +650,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'A');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -656,6 +671,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 1);
         BOOST_CHECK_EQUAL(buffer[0], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -677,6 +693,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(buffer[0], 'T');
         BOOST_CHECK_EQUAL(buffer[1], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -698,6 +715,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(buffer[0], 'T');
         BOOST_CHECK_EQUAL(buffer[1], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -718,6 +736,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(written, 0);
         //BOOST_CHECK_EQUAL(buffer[0], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -745,6 +764,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(buffer[6], 'n');
         BOOST_CHECK_EQUAL(buffer[7], 'n');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -769,6 +789,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(buffer[2], 'n');
         BOOST_CHECK_EQUAL(buffer[3], 'n');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -793,6 +814,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         //BOOST_CHECK_EQUAL(buffer[2], 'T');
         //BOOST_CHECK_EQUAL(buffer[3], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -816,6 +838,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(buffer[0], 'C');
         BOOST_CHECK_EQUAL(buffer[1], 'T');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -875,6 +898,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         written = fs.view_sequence_region_size((strchr(arg, '/') + 5));
         BOOST_CHECK_EQUAL(written, 15);
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -898,6 +922,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         BOOST_CHECK_EQUAL(buffer[0], 'T');
         BOOST_CHECK_EQUAL(buffer[1], 'G');
 
+        delete cache_p0;
         delete[] buffer;
     }
 
@@ -919,6 +944,7 @@ BOOST_AUTO_TEST_CASE(test_fastafs__sequence_virtualization)
         written = fs.view_sequence_region(cache_p0, (strchr(arg, '/') + 5), buffer, READ_BUFFER_SIZE, 0); // small buffer size
         BOOST_CHECK_EQUAL(written, 0);
 
+        delete cache_p0;
         delete[] buffer;
     }
 }

--- a/test/fastafs/test_ucsc2bit.cpp
+++ b/test/fastafs/test_ucsc2bit.cpp
@@ -470,8 +470,6 @@ BOOST_AUTO_TEST_CASE(test_fastafs_view_chunked_2bit_with_offset)
             fs.view_ucsc2bit_chunk(buffer, complen, file_offset);
             BOOST_CHECK_EQUAL_MESSAGE(reference.compare(file_offset, complen, std_string_nullbyte_safe(buffer, 0, complen), 0, complen), 0, "Failed during len=" << complen << " and file offset=" << file_offset);
         }
-
-        printf("\n");
     }
     //for(uint32_t i = 0; i < complen; i++) {
     //printf("ref[%i]: %u\t == buf[%i]: %u",i + file_offset,  (signed char) reference[i + file_offset], i, (signed char) buffer[i], (unsigned char) buffer[i]);

--- a/test/view/test_view.cpp
+++ b/test/view/test_view.cpp
@@ -541,6 +541,7 @@ BOOST_AUTO_TEST_CASE(test_chunked_viewing_fourbit)
     delete cache_p1;
     delete cache_p4;
     delete cache_p5;
+    delete cache_p32;
     delete cache_p999;
 }
 


### PR DESCRIPTION
 - [x] x-check valgrind & free's
 - [x] remove `MD5_DIGEST_LENGTH` in favor of `EVP_MD_size(EVP_md5())` - as it gets likely deprecated
 - [x] same as above, for SHA1